### PR TITLE
Update items_decoder.cpp

### DIFF
--- a/items_decoder.cpp
+++ b/items_decoder.cpp
@@ -270,7 +270,7 @@ int main()
 			// TODO: find what those data mean
 			memPos += 13;
 		}
-                If (itemsdatVersion >= 13) {
+                if(itemsdatVersion >= 13) {
                       memPos += 4;
                 }
 		if (i != itemID)


### PR DESCRIPTION
Keyword happens to be case-sensitive; preventing an 'IF was not declared in this scope' error when compiling.